### PR TITLE
Ensure policy end dates are always present and enforced

### DIFF
--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -15,11 +15,11 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             .HasIndex(c => c.Vin)
             .IsUnique(false); // TODO: set true and handle conflicts
 
-        modelBuilder.Entity<InsurancePolicy>()
-            .Property(p => p.StartDate)
-            .IsRequired();
-
-        // EndDate intentionally left nullable for a later task
+        modelBuilder.Entity<InsurancePolicy>(e =>
+        {
+            e.Property(p => p.StartDate).IsRequired(); 
+            e.Property(p => p.EndDate).IsRequired();     
+        });
     }
 }
 
@@ -41,7 +41,7 @@ public static class SeedData
 
         db.Policies.AddRange(
             new InsurancePolicy { CarId = car1.Id, Provider = "Allianz", StartDate = new DateOnly(2024,1,1), EndDate = new DateOnly(2024,12,31) },
-            new InsurancePolicy { CarId = car1.Id, Provider = "Groupama", StartDate = new DateOnly(2025,1,1), EndDate = null }, // open-ended on purpose
+            new InsurancePolicy { CarId = car1.Id, Provider = "Groupama", StartDate = new DateOnly(2025,1,1), EndDate = new DateOnly(2025, 12, 31) },
             new InsurancePolicy { CarId = car2.Id, Provider = "Allianz", StartDate = new DateOnly(2025,3,1), EndDate = new DateOnly(2025,9,30) }
         );
         db.SaveChanges();

--- a/Models/InsurancePolicy.cs
+++ b/Models/InsurancePolicy.cs
@@ -1,5 +1,5 @@
 namespace CarInsurance.Api.Models;
-
+using System.ComponentModel.DataAnnotations;
 public class InsurancePolicy
 {
     public long Id { get; set; }
@@ -9,5 +9,7 @@ public class InsurancePolicy
 
     public string? Provider { get; set; }
     public DateOnly StartDate { get; set; }
-    public DateOnly? EndDate { get; set; } // intentionally nullable; will be enforced later
+
+    [Required]
+    public DateOnly EndDate { get; set; } 
 }


### PR DESCRIPTION
- Make `EndDate` required at both the model level and the database level.
- Update seed data so all policies have a valid `EndDate`.